### PR TITLE
Add env var to handle node sass on alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="hitalos <hitalos@gmail.com>"
 
 # Download and install NodeJS
 ENV NODE_VERSION 10.4.1
+ENV NODE_SASS_PLATFORM alpine 
 ADD install-node.sh /usr/sbin/install-node.sh
 RUN /usr/sbin/install-node.sh
 RUN npm i -g yarn


### PR DESCRIPTION
Please check if it works because I couldn't find the `install-nodejs.sh` file. I replaced it with `apk add --update nodejs` and add the important `ENV NODE_SASS_PLATFORM alpine`. I found this solution here https://github.com/sass/node-sass/issues/1589#issuecomment-266280717. #14  @hitalos 